### PR TITLE
Added details to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ Flatery is icon theme for linux in flat style licensed under the CC BY-NC-SA 3.0
 
 
 ## Installation:
-Just extract Flattery to ~/.icons or ~/.local/share/icons or /usr/share/icons
+After downloading/extracting, move the `Flatery` and `Flatery-Dark` folders to `/usr/share/icons` if you want them to be visible for all users.
+If you want them to be visible only to your user, move them to `~/.icons` (GTK-based distros) or `~/.local/share/icons` (KDE-based distros).
+
+Similarily move the `Flatery-wallpapers` folder to `/usr/share/wallpapers` or `~/.local/share/wallpapers`.
 
  
 ## Support


### PR DESCRIPTION
Specified which specific icons folders to move (Flatery & Flatery-Dark) and where to move them for them to properly work on GTK VS KDE-based distros.
Also added instructions for where to move Flatery-wallpapers folder.

Just thought this would be worth making explicit since I naively extracted the whole thing to `~/.local/share/icons` and it took me a while to figure out why the icons & wallpapers weren't appearing in my settings.