### PR TITLE
Added an install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,19 @@ Flatery is icon theme for linux in flat style licensed under the CC BY-NC-SA 3.0
 
 
 ## Installation:
-After downloading/extracting, move the `Flatery` and `Flatery-Dark` folders to `/usr/share/icons` if you want them to be visible for all users.
+
+### Install script
+After downloading/extracting, open a terminal in this directory and execute the install script `./install.sh`  
+By default, all variants are installed for the current user and wallpapers are not installed.
+
+* Option `-g` installs globally, needs root privileges
+* Option `-v` allows to choose variants (eg. `./install.sh -v "Orange Orange-Dark Mint"`)
+* Option `-w` installs wallpapers  
+Use `./install.sh -w -v ""` to install only the wallpapers.
+
+
+### Manual installation
+After downloading/extracting, move the `Flatery` and `Flatery-Dark` folders to `/usr/share/icons` if you want them to be visible for all users.  
 If you want them to be visible only to your user, move them to `~/.icons` (GTK-based distros) or `~/.local/share/icons` (KDE-based distros).
 
 Similarily move the `Flatery-wallpapers` folder to `/usr/share/wallpapers` or `~/.local/share/wallpapers`.

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,8 @@ iconsVariants=$(ls | grep "Flatery-" | grep -v "wallpapers" | cut -f 2- -d "-")
 installWallpapers=false
 wallpapersDir=$HOME/.local/share/backgrounds
 
+badVariant=false
+
 function show_valid_variants {
 	echo "Valid variants are : $iconsVariants" 
 }
@@ -76,13 +78,22 @@ while getopts ":hgwv:" opt; do
 	esac
 done
 
-# Check write permissions for install dir
-badVariant=false
-if [[ -w $iconsDir ]]; then
 
+# Check if any variant is selected
+if [[ -z $iconsVariants ]]; then
+	
+	echo "No icons will be installed."
+
+else
+
+	# Check write permissions
+	if [[ ! -w $iconsDir ]]; then
+		echo "Can't write to $iconsDir"
+		exit 2
+	fi
+
+	# Install icons variants
 	echo "Installing icons into $iconsDir"
-
-	# Apply icons variants
 	for variant in $iconsVariants; do
 		if [[ -d "Flatery-$variant" ]]; then 
 			echo "	Installing variant $variant"
@@ -94,39 +105,28 @@ if [[ -w $iconsDir ]]; then
 		fi
 	done
 	
-else 
-
-	# Error, can't write
-	echo "Can't write to $iconsDir"
-	exit 2
-
 fi
 
 
-# Install wallpapers
+# Check if wallpapers are selected for install
 if $installWallpapers; then
-	if [[ -w $wallpapersDir ]]; then
-		
-		echo "Installing wallpapers into $wallpapersDir"  
-
-		# Install wallpapers
-		rm -rf $wallpapersDir/Flatery-wallpapers
-		cp -r Flatery-wallpapers $wallpapersDir
-
-	else 
-
-		# Error, can't write
+	
+	# Check write permissions
+	if [[ ! -w $wallpapersDir ]]; then
 		echo "Can't write to $wallpapersDir"
 		exit 2	
-
 	fi
+	
+	# Install wallpapers
+	echo "Installing wallpapers into $wallpapersDir"  
+	rm -rf $wallpapersDir/Flatery-wallpapers
+	cp -r Flatery-wallpapers $wallpapersDir
+	
 fi
 
-# Exit
+# Exit with appropriate code
 if $badVariant; then
-	# Low severity error, bad variant
 	exit 1
 else
-	# Everything went good
 	exit 0
 fi

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# Default install all variants for user only
+iconsDir=$HOME/.local/share/icons
+iconsVariants=$(ls | grep "Flatery-" | grep -v "wallpapers" | cut -f 2- -d "-")
+
+installWallpapers=false
+wallpapersDir=$HOME/.local/share/backgrounds
+
+function show_valid_variants {
+	echo "Valid variants are : $iconsVariants" 
+}
+
+# Parsing options
+while getopts "gwv:" opt; do
+	case ${opt} in
+		g ) 
+			# Install globally
+			iconsDir=/usr/share/icons
+			wallpapersDir=/usr/share/backgrounds
+			;;
+		v )
+			# Install only user selected variant(s)
+			iconsVariants="$OPTARG"
+			;;
+		w )
+			# Install wallpaper(s)
+			installWallpapers=true
+			;;
+		: )
+			# Given variant does not exist
+			show_valid_variants
+			exit 1
+			;;
+	esac
+done
+
+# Check write permissions for install dir
+if [[ -w $iconsDir ]]; then
+
+	echo "Installing icons into $iconsDir"
+
+	# Apply icons variants
+	for variant in $iconsVariants; do
+		if [[ -d "Flatery-$variant" ]]; then 
+			echo "	Installing variant $variant"
+			rm -rf $iconsDir/$variant	
+			cp -r Flatery-$variant $iconsDir
+		else
+			echo "Variant $variant does not exist"
+		fi
+	done
+	
+else 
+
+	# Error, can't write
+	echo "Can't write to $iconsDir"
+	exit 1	
+
+fi
+
+
+# Install wallpapers
+if $installWallpapers; then
+	if [[ -w $wallpapersDir ]]; then
+		
+		echo "Installing wallpapers into $wallpapersDir"  
+
+		# Install wallpapers
+		rm -rf $wallpapersDir/Flatery-wallpapers
+		cp -r Flatery-wallpapers $wallpapersDir
+
+	else 
+
+		# Error, can't write
+		echo "Can't write to $wallpapersDir"
+		exit 1	
+
+	fi
+fi
+
+# If everything went good, exit with code 0
+exit 0


### PR DESCRIPTION
Added an install script, which by default installs all icons variants for the current user without the wallpapers.

* If the -v option is given it specifies variants.
Eg `./install.sh -v "Mint Orange"`
* If the -w option is given, wallpapers are installed too
* If the -g option is given, installations are global

Wallpapers are not installed by default because it's an icon theme and users don't expect wallpapers from it I think.
Let me know if you want to change default behavior or anything. 