### PR TITLE
added links for mimetype application/x-iso9660-image

### DIFF
--- a/Flatery-Dark/mimetypes/16/application-x-iso9660-image.svg
+++ b/Flatery-Dark/mimetypes/16/application-x-iso9660-image.svg
@@ -1,0 +1,1 @@
+application-x-iso.svg

--- a/Flatery-Dark/mimetypes/22/application-x-iso9660-image.svg
+++ b/Flatery-Dark/mimetypes/22/application-x-iso9660-image.svg
@@ -1,0 +1,1 @@
+application-x-iso.svg

--- a/Flatery-Dark/mimetypes/24/application-x-iso9660-image.svg
+++ b/Flatery-Dark/mimetypes/24/application-x-iso9660-image.svg
@@ -1,0 +1,1 @@
+application-x-iso.svg

--- a/Flatery-Dark/mimetypes/32/application-x-iso9660-image.svg
+++ b/Flatery-Dark/mimetypes/32/application-x-iso9660-image.svg
@@ -1,0 +1,1 @@
+application-x-iso.svg

--- a/Flatery-Dark/mimetypes/48/application-x-iso9660-image.svg
+++ b/Flatery-Dark/mimetypes/48/application-x-iso9660-image.svg
@@ -1,0 +1,1 @@
+application-x-iso.svg

--- a/Flatery-Dark/mimetypes/64/application-x-iso9660-image.svg
+++ b/Flatery-Dark/mimetypes/64/application-x-iso9660-image.svg
@@ -1,0 +1,1 @@
+application-x-iso.svg

--- a/Flatery/mimetypes/16/application-x-iso9660-image.svg
+++ b/Flatery/mimetypes/16/application-x-iso9660-image.svg
@@ -1,0 +1,1 @@
+application-x-iso.svg

--- a/Flatery/mimetypes/22/application-x-iso9660-image.svg
+++ b/Flatery/mimetypes/22/application-x-iso9660-image.svg
@@ -1,0 +1,1 @@
+application-x-iso.svg

--- a/Flatery/mimetypes/24/application-x-iso9660-image.svg
+++ b/Flatery/mimetypes/24/application-x-iso9660-image.svg
@@ -1,0 +1,1 @@
+application-x-iso.svg

--- a/Flatery/mimetypes/32/application-x-iso9660-image.svg
+++ b/Flatery/mimetypes/32/application-x-iso9660-image.svg
@@ -1,0 +1,1 @@
+application-x-iso.svg

--- a/Flatery/mimetypes/48/application-x-iso9660-image.svg
+++ b/Flatery/mimetypes/48/application-x-iso9660-image.svg
@@ -1,0 +1,1 @@
+application-x-iso.svg

--- a/Flatery/mimetypes/64/application-x-iso9660-image.svg
+++ b/Flatery/mimetypes/64/application-x-iso9660-image.svg
@@ -1,0 +1,1 @@
+application-x-iso.svg


### PR DESCRIPTION
### Problem
ISO files are usually expressed as mimetype `application/x-iso9660-image`<sup>[1](https://en.wikipedia.org/wiki/Optical_disc_image)</sup>. The SVGs that would represent it are are missing, so ISO files appear as unknown files.

### Solution
I created symlinks from every `*/mimetypes/*/application-x-iso9660-image.svg` to their respective sibling `application-x-iso.svg` files.